### PR TITLE
Cta Updates

### DIFF
--- a/content/source/assets/stylesheets/_home.scss
+++ b/content/source/assets/stylesheets/_home.scss
@@ -282,10 +282,11 @@
     }
 
     &#enterprise {
-      background-image: image-url('enterprise-callout-bg.svg');
-      background-position: right bottom;
-      background-repeat: no-repeat;
-      background-size: 80%;
+      background: #0F1013;
+
+      & .button {
+        margin: 5px;
+      }
     }
   }
 

--- a/content/source/assets/stylesheets/_home.scss
+++ b/content/source/assets/stylesheets/_home.scss
@@ -2,6 +2,11 @@
   // Override the main header
   #header {
     background: $home-header-background-color;
+    margin-bottom: 56px;
+    
+    @media (min-width: $screen-sm-min) {
+      margin-bottom: 128px;
+    }
 
     .navbar-toggle {
       .icon-bar {
@@ -50,10 +55,19 @@
     }
   }
 
+  .notification {
+    display: inline-flex;
+    margin-top: 0;
+  }
+
   header {
     .hero {
-      margin: 140px auto 160px auto;
+      margin: 80px auto;
       text-align: center;
+
+      @media (max-width: $screen-xs-max) {
+        margin-bottom: 0;
+      }
 
       .button {
         margin: 5px;

--- a/content/source/assets/stylesheets/_notification.scss
+++ b/content/source/assets/stylesheets/_notification.scss
@@ -1,55 +1,58 @@
 .notification {
-  background: #f7f7fd;
-  border-radius: 3px;
+  align-items: flex-start;
+  background: #f5f3ff;
+  border-radius: 2px;
   color: $black;
-  display: inline-block;
-  font-size: 1.4rem;
-  padding: 7px 6px 6px;
-  line-height: 1.7;
-  transition: all 0.3s ease-in-out;
+  display: flex;
+  font-size: 1.6rem;
+  font-weight: $font-weight-bold;
+  line-height: 2.8rem;
+  margin: 48px 0 64px;
+  padding: 6px 13px;
+  transition: all 0.2s ease-in-out;
 
   &:hover {
-    background: #f1f1fe;
+    background: #f0eefa;
     color: $black;
     text-decoration: none;
   }
 
-  @media (min-width: 768px) {
-    position: absolute;
-    top: 0;
-    left: 0;
-  }
+  & .notification-tag {
+    margin: -1px 18px 0 0;
 
-  @media (min-width: 992px) {
-    line-height: 1.4;
+    & span {
+      border: 1px solid $terraform-purple;
+      background-color: $white;
+      border-radius: 2px;
+      font-size: 1.1rem;
+      font-weight: $font-weight-reg;
+      line-height: 2;
+      padding: 3px 11px;
+      text-transform: uppercase;
+    }
 
-    .notification-details{
-      display: flex;
+    @media (min-width: $screen-md-min) {
+      margin-right: 32px;
     }
   }
 
-  .notification-tag {
-    border: 1px solid $terraform-purple;
-    background-color: $white;
-    border-radius: 3px;
-    color: $terraform-purple;
-    display: inline-block;
-    font-size: 1.2rem;
-    font-weight: 700;
-    margin-top: -1px;
-    margin-right: 4px;
-    padding: 2px 9px;
-    text-transform: uppercase;
+  & .notification-text {
+    text-align: left;
+  }
 
-    @media (min-width: 992px) {
-      float: left;
-      margin-right: 8px;
+  .notification-link {
+    align-items: center;
+    color: $terraform-purple;
+    display: none;
+    margin-left: 32px;
+    text-decoration: underline;
+    
+    @media (min-width: $screen-md-min) {
+      display: inline-flex;
     }
   }
 
   svg {
-    margin-left: 4px;
-    margin-right: 6px;
-    align-self: center;
+    margin: 0 10px 0 16px;
   }
 }

--- a/content/source/docs/index.html.markdown
+++ b/content/source/docs/index.html.markdown
@@ -5,6 +5,7 @@ sidebar_current: "docs-frontpage"
 description: |-
   A brief map of the documentation for Terraform CLI, Terraform Enterprise, the
   Terraform GitHub Actions, and the rest of the Terraform ecosystem.
+show_notification: true
 ---
 
 # Terraform Documentation

--- a/content/source/downloads.html.erb
+++ b/content/source/downloads.html.erb
@@ -4,6 +4,7 @@ page_title: "Download Terraform"
 sidebar_current: "downloads-terraform"
 description: |-
   Download Terraform
+show_notification: true
 ---
 
 <h1>Download Terraform</h1>

--- a/content/source/index.html.erb
+++ b/content/source/index.html.erb
@@ -12,20 +12,16 @@ description: |-
 <% end %>
 
 <header>
-  <div class="container">
-    <div class="row">
-      <div class="col-md-12">
-      <a class="notification" href='https://app.terraform.io/signup'>
-        <span class="notification-tag">Sign Up</span>
-          Free Terraform Enterprise tier for practitioners and small teams.
-          <svg width="15" height="9" viewBox="0 0 15 9" fill="none" xmlns="http://www.w3.org/2000/svg"><line x1="0.5" y1="4.5" x2="13.5" y2="4.5" stroke="#5147CD" stroke-linecap="round"></line><path d="M10.3536 0.646447C10.1583 0.451184 9.84171 0.451184 9.64645 0.646447C9.45118 0.841709 9.45118 1.15829 9.64645 1.35355L10.3536 0.646447ZM13.5 4.5L13.8536 4.85355L14.2071 4.5L13.8536 4.14645L13.5 4.5ZM9.64645 7.64645C9.45118 7.84171 9.45118 8.15829 9.64645 8.35355C9.84171 8.54882 10.1583 8.54882 10.3536 8.35355L9.64645 7.64645ZM9.64645 1.35355L13.1464 4.85355L13.8536 4.14645L10.3536 0.646447L9.64645 1.35355ZM13.1464 4.14645L9.64645 7.64645L10.3536 8.35355L13.8536 4.85355L13.1464 4.14645Z" fill="#5147CD"></path></svg>
-      </a>
-      </div>
-    </div>
-  </div>
   <div class="container hero">
     <div class="row">
+      <div class='col-sm-12'>
+        <%= partial("layouts/notification") %>
+      </div>
+    </div>
+
+    <div class="row">
       <div class="col-md-offset-2 col-md-8">
+
         <%= inline_svg "logo-hashicorp.svg", height: 120, class: "logo" %>
 
         <h1>Write, Plan, and Create Infrastructure as Code</h1>
@@ -321,13 +317,12 @@ description: |-
       <div class="col-md-offset-2 col-md-8 text-center">
         <h2>Introducing Terraform Cloud</h2>
         <p class="lead">
-          Terraform collaboration for everyone. Cras mattis consectetur purus sit 
-          amet fermentum. Vestibulum id ligula porta felis euismod semper. Donec 
-          id elit non mi porta gravida at eget metus.
+          Collaboration for everyone. Terraform Cloud is a platform that provides 
+          collaboration features to Terraform users team management, self-service 
+          infrastructure and governance.
         </p>
         <p>
           <a class="button primary" href="https://app.terraform.io/signup">Sign Up for Free</a>
-          <a class="button" href="https://www.hashicorp.com/terraform.html">Contact Sales</a>
         </p>
       </div>
     </div>

--- a/content/source/index.html.erb
+++ b/content/source/index.html.erb
@@ -318,15 +318,16 @@ description: |-
 <section id="enterprise" class="marketing black">
   <div class="container">
     <div class="row">
-      <div class="col-sm-7">
-        <%= inline_svg "terraform-enterprise-logo.svg", width: 300 %>
+      <div class="col-md-offset-2 col-md-8 text-center">
+        <h2>Introducing Terraform Cloud</h2>
         <p class="lead">
-          Collaborative Infrastructure Automation for organizations. Collaborate
-          on Terraform configurations, validate changes, and automate
-          provisioning across providers.
+          Terraform collaboration for everyone. Cras mattis consectetur purus sit 
+          amet fermentum. Vestibulum id ligula porta felis euismod semper. Donec 
+          id elit non mi porta gravida at eget metus.
         </p>
         <p>
-          <a class="button" href="https://www.hashicorp.com/terraform.html">Learn More</a>
+          <a class="button primary" href="https://app.terraform.io/signup">Sign Up for Free</a>
+          <a class="button" href="https://www.hashicorp.com/terraform.html">Contact Sales</a>
         </p>
       </div>
     </div>

--- a/content/source/layouts/_notification.erb
+++ b/content/source/layouts/_notification.erb
@@ -1,0 +1,13 @@
+
+<a class="notification" href="https://app.terraform.io/signup">
+  <div class="notification-tag">
+    <span>New</span>
+  </div>
+  <div class="notification-text">
+    <span>Introducing Terraform Cloud Remote State Management</span>
+    <span class="notification-link">
+        Sign Up For Free
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 12H20" stroke="#5F43E9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path d="M14 6L20 12L14 18" stroke="#5F43E9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+    </span>
+  </div>
+</a>

--- a/content/source/layouts/layout.erb
+++ b/content/source/layouts/layout.erb
@@ -121,6 +121,16 @@
       </div>
     </div>
 
+    <% if current_page.data.show_notification == true %>
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-12 text-center">
+          <%= partial("layouts/notification") %>
+        </div>
+      </div>
+    </div>
+    <% end %>
+
     <%= partial("layouts/sidebar", locals: {docs_items: docs_items}) %>
 
     <%= yield %>


### PR DESCRIPTION
This PR will make the following website adjustments as requested by the product marketing team at HashiCorp:

- Add "Introducing Terraform Cloud" cta section to bottom of the home page.
- Update notification content to showcase Terraform Cloud
- Style updates for alert notifications with styles for both the home page as well as documentation pages.
- Add notification partial to allow for editing notification in a single place

![Screen Shot 2019-05-06 at 1 19 13 PM](https://user-images.githubusercontent.com/5368111/57658073-bbf01e80-759a-11e9-9d0a-8d641a1e9fa6.png)

---

<img width="1165" alt="Screen Shot 2019-05-13 at 3 59 19 PM" src="https://user-images.githubusercontent.com/5368111/57658087-c8747700-759a-11e9-9135-59ab42c86036.png">

<img width="484" alt="Screen Shot 2019-05-13 at 3 59 33 PM" src="https://user-images.githubusercontent.com/5368111/57658088-c8747700-759a-11e9-9c03-61931e2c0285.png">

---

<img width="1243" alt="Screen Shot 2019-05-13 at 3 59 54 PM" src="https://user-images.githubusercontent.com/5368111/57658089-c8747700-759a-11e9-96b1-e1bf35fa94f2.png">

<img width="474" alt="Screen Shot 2019-05-13 at 4 00 07 PM" src="https://user-images.githubusercontent.com/5368111/57658090-c8747700-759a-11e9-8e1d-39a204ea8f16.png">
